### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-_site
+### Jekyll ###
+_site/
+.sass-cache/
+.jekyll-metadata


### PR DESCRIPTION
Now ignores all the correct jekyll files